### PR TITLE
Logging error when caught

### DIFF
--- a/jhotdraw-datatransfer/src/main/java/org/jhotdraw/datatransfer/OSXClipboard.java
+++ b/jhotdraw-datatransfer/src/main/java/org/jhotdraw/datatransfer/OSXClipboard.java
@@ -32,7 +32,7 @@ public class OSXClipboard extends AWTClipboard {
         t = ct;
       }
     } catch (Throwable ex) {
-      // silently suppress
+      ex.printStackTrace();
     }
     return t;
   }


### PR DESCRIPTION
Added printStackTrace() to log the error 'ex' when caught. but there is also the possiblity of calling getMessage() , getCause() , and toString() methods that can be called on 'ex' , is my way of logging right ? not sure of my choice.