### PR TITLE
Added comments for methods

### DIFF
--- a/jhotdraw-core/src/main/java/org/jhotdraw/draw/event/FigureListenerAdapter.java
+++ b/jhotdraw-core/src/main/java/org/jhotdraw/draw/event/FigureListenerAdapter.java
@@ -13,24 +13,38 @@ package org.jhotdraw.draw.event;
  */
 public class FigureListenerAdapter implements FigureListener {
 
+  /** Sent when the drawing area used by the figure needs to be repainted. */
   @Override
   public void areaInvalidated(FigureEvent e) {}
 
+  /** Sent when an attribute of the figure has changed. */
   @Override
   public void attributeChanged(FigureEvent e) {}
 
+  /** Sent when a figure was added to a drawing. */
   @Override
   public void figureAdded(FigureEvent e) {}
 
+  /** Sent when a figure was removed from a drawing. */
   @Override
   public void figureChanged(FigureEvent e) {}
 
+  /** Sent when the geometry (for example the bounds) of the figure has changed. */
   @Override
   public void figureRemoved(FigureEvent e) {}
 
+  /** Sent when the figure requests to be removed from a drawing. */
   @Override
   public void figureRequestRemove(FigureEvent e) {}
 
+  /**
+   * Sent when handles of a Figure have been added, removed or replaced.
+   *
+   * <p>DrawingViews listen to this event to repopulate the Handles.
+   *
+   * <p>A Figure should not fire this event, if just the state or the location of Handle has
+   * changed.
+   */
   @Override
   public void figureHandlesChanged(FigureEvent e) {}
 }


### PR DESCRIPTION
the FigureListenerAdapter class overrides the FigureListener methods, but it lacks the comments for what each method does. So I imported them from the FigureListener to avoid jumping from files just to read comments.